### PR TITLE
Compile library for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,5 @@
 /windows/Release
 /windows/x64/Debug
 /windows/x64/Release
-/windows/.vs/FloppyBridge/v16
-/floppybridge/.vs/FloppyBridge/v16
+/windows/.vs/
+/floppybridge/.vs/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+TARGET  = FloppyBridge.so
+
+SOURCE  = floppybridge/ArduinoFloppyBridge.cpp \
+          floppybridge/ArduinoInterface.cpp \
+          floppybridge/CommonBridgeTemplate.cpp \
+          floppybridge/ftdi.cpp \
+          floppybridge/GreaseWeazleBridge.cpp \
+          floppybridge/GreaseWeazleInterface.cpp \
+          floppybridge/RotationExtractor.cpp \
+          floppybridge/SerialIO.cpp \
+          floppybridge/SuperCardProBridge.cpp \
+          floppybridge/SuperCardProInterface.cpp
+DEPS	= $(SOURCE:%.cpp=%.d)
+
+CPPFLAGS +=-shared -ldl
+
+.PHONY : all clean
+
+$(TARGET) : $(SOURCE)
+	g++ $(CPPFLAGS) -o $(TARGET) $(SOURCE)
+
+all : $(TARGET)
+
+install : $(TARGET)
+	cp $(TARGET) /usr/lib
+
+clean :
+	rm -f $(DEPS)
+	rm -f $(TARGET)
+
+cleanprofile:
+	rm -f $(OBJS:%.o=%.gcda)
+
+-include $(DEPS)

--- a/floppybridge/floppybridge_lib.cpp
+++ b/floppybridge/floppybridge_lib.cpp
@@ -170,7 +170,9 @@ _BRIDGE_SetProfileConfigFromString BRIDGE_SetProfileConfigFromString = nullptr;
 _BRIDGE_SetProfileName BRIDGE_SetProfileName = nullptr;
 _BRIDGE_CreateNewProfile BRIDGE_CreateNewProfile = nullptr;
 _BRIDGE_DeleteProfile BRIDGE_DeleteProfile = nullptr;
+#ifdef _WIN32
 _BRIDGE_ShowConfigDialog BRIDGE_ShowConfigDialog = nullptr;
+#endif
 _BRIDGE_GetDriverIndex BRIDGE_GetDriverIndex = nullptr;
 _BRIDGE_FreeDriver	BRIDGE_FreeDriver = nullptr;
 _BRIDGE_DriverGetMode	BRIDGE_DriverGetMode = nullptr;
@@ -245,8 +247,10 @@ void prepareBridge() {
 	BRIDGE_EnumComports = (_BRIDGE_EnumComports)GETFUNC(hBridgeDLLHandle, "BRIDGE_EnumComports");
 	BRIDGE_GetDriverInfo = (_BRIDGE_GetDriverInfo)GETFUNC(hBridgeDLLHandle, "BRIDGE_GetDriverInfo");
 	BRIDGE_CreateDriver = (_BRIDGE_CreateDriver)GETFUNC(hBridgeDLLHandle, "BRIDGE_CreateDriver");
-	BRIDGE_GetDriverIndex = (_BRIDGE_GetDriverIndex)GETFUNC(hBridgeDLLHandle, "BRIDGE_GetDriverIndex");	
+	BRIDGE_GetDriverIndex = (_BRIDGE_GetDriverIndex)GETFUNC(hBridgeDLLHandle, "BRIDGE_GetDriverIndex");
+#ifdef _WIN32
 	BRIDGE_ShowConfigDialog = (_BRIDGE_ShowConfigDialog)GETFUNC(hBridgeDLLHandle, "BRIDGE_ShowConfigDialog");
+#endif
 	BRIDGE_Close = (_BRIDGE_Close)GETFUNC(hBridgeDLLHandle, "BRIDGE_Close");
 	BRIDGE_Open = (_BRIDGE_Open)GETFUNC(hBridgeDLLHandle, "BRIDGE_Open");
 	BRIDGE_CreateDriverFromProfileID = (_BRIDGE_CreateDriverFromProfileID)GETFUNC(hBridgeDLLHandle, "BRIDGE_CreateDriverFromProfileID");


### PR DESCRIPTION
A few more improvements, related to Linux (but not only!):
- Updated git ignore file, to ignore Visual Studio files under .vs
- Added `ifdef` sections for ShowConfigDialog, to only use it under Windows. At least for now.
- Added Linux Makefile, to compile library.

You can now use `make` to compile a dynamic library under Linux in the current directory.
Then you can use `sudo make install` to install the compiled library in the system (it goes in `/usr/lib`)