### PR TITLE
Copy library to /usr/local/lib when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(TARGET) : $(SOURCE)
 all : $(TARGET)
 
 install : $(TARGET)
-	cp $(TARGET) /usr/lib
+	cp $(TARGET) /usr/local/lib
 
 clean :
 	rm -f $(DEPS)


### PR DESCRIPTION
Minor update, to place the library in the "proper" path as per GNU documentation