### PR TITLE
More Linux-specific fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ SOURCE  = floppybridge/ArduinoFloppyBridge.cpp \
           floppybridge/RotationExtractor.cpp \
           floppybridge/SerialIO.cpp \
           floppybridge/SuperCardProBridge.cpp \
-          floppybridge/SuperCardProInterface.cpp
+          floppybridge/SuperCardProInterface.cpp \
+          windows/FloppyBridge.cpp
 DEPS	= $(SOURCE:%.cpp=%.d)
 
-CPPFLAGS +=-shared -fPIC -ldl
+CPPFLAGS +=-shared -fPIC -ldl -Ifloppybridge -Iwindows
 
 .PHONY : all clean
 

--- a/windows/FloppyBridge.cpp
+++ b/windows/FloppyBridge.cpp
@@ -23,7 +23,7 @@
 * https://github.com/RobSmithDev/FloppyDriveBridge
 */
 
-
+#include <cstring>
 #include "FloppyBridge.h"
 #include "resource.h"
 
@@ -33,15 +33,15 @@
 #define ROMTYPE_GREASEWEAZLEREADER_WRITER
 #define ROMTYPE_SUPERCARDPRO_WRITER
 
-#include "../floppybridge/ArduinoFloppyBridge.h"
-#include "../floppybridge/GreaseWeazleBridge.h"
-#include "../floppybridge/SupercardProBridge.h"
+#include "ArduinoFloppyBridge.h"
+#include "GreaseWeazleBridge.h"
+#include "SuperCardProBridge.h"
 
 #ifdef _WIN32
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #include <WinSock2.h>
-#include "../windows/bridgeProfileListEditor.h"
-#include "../windows/bridgeProfileEditor.h"
+#include "bridgeProfileListEditor.h"
+#include "bridgeProfileEditor.h"
 
 HINSTANCE hInstance;
 

--- a/windows/FloppyBridge.cpp
+++ b/windows/FloppyBridge.cpp
@@ -56,7 +56,9 @@ HINSTANCE hInstance;
 static BridgeAbout BridgeInformation = { "FloppyBridge, Copyright(C) 2021 Robert Smith (@RobSmithDev)", "https://amiga.robsmithdev.co.uk/winuae", 0, 9, 1, 0, 0};
 static bool hasUpdateChecked = false;
 std::vector<SerialIO::SerialPortInformation> serialports;
+#ifdef _WIN32
 std::vector<HBITMAP> bridgeLogos;
+#endif
 std::unordered_map<unsigned int, BridgeConfig*> profileList;
 FloppyBridgeProfileInformationDLL* profileCache = nullptr;
 std::string profileStringExported;
@@ -145,7 +147,7 @@ void handleAbout(bool checkForUpdates, BridgeAbout** output) {
         // Start winsock
         WSADATA data;
         WSAStartup(MAKEWORD(2, 0), &data);
-#endif
+
         // Fetch version from 'A' record in the DNS record
         hostent* address = gethostbyname("floppybridge-amiga.robsmithdev.co.uk");
         if ((address) && (address->h_addrtype == AF_INET)) {
@@ -158,6 +160,7 @@ void handleAbout(bool checkForUpdates, BridgeAbout** output) {
                     ((BridgeInformation.majorVersion == BridgeInformation.updateMajorVersion) && (BridgeInformation.minorVersion < BridgeInformation.updateMinorVersion))) ? 1 : 0;
             }
         }
+#endif
     }
 
     if (output) *output = (BridgeAbout*)&BridgeInformation;
@@ -213,7 +216,11 @@ extern "C" {
                 quickw2a(port.portName, tmp);
 
                 // Copy name
+#ifdef _WIN32
                 memcpy_s(output, lengthRequired, tmp.c_str(), tmp.length());
+#else
+                memcpy(output, tmp.c_str(), tmp.length());
+#endif
                 lengthRequired -= tmp.length();
 
                 // Add seperator
@@ -403,7 +410,7 @@ extern "C" {
 #ifdef _WIN32
         strcpy_s(f->second->profileName, 128, profileName);
 #else
-        strcpy(f->second->profileName, 128, profileName);
+        strncpy(f->second->profileName, profileName, 128);
 #endif
         return true;
     }

--- a/windows/FloppyBridge.cpp
+++ b/windows/FloppyBridge.cpp
@@ -154,8 +154,14 @@ void handleAbout(bool checkForUpdates, BridgeAbout** output) {
             if (address->h_addr_list[0] != 0) {
                 in_addr add = *((in_addr*)address->h_addr_list[0]);
 
+#ifdef _WIN32
                 BridgeInformation.updateMajorVersion = add.S_un.S_un_b.s_b1;
                 BridgeInformation.updateMinorVersion = add.S_un.S_un_b.s_b2;
+#else
+                uint32_t bytes = htonl(add.s_addr);
+                BridgeInformation.updateMajorVersion = bytes >> 24;
+                BridgeInformation.updateMinorVersion = (bytes >> 16) & 0xFF;
+#endif  
                 BridgeInformation.isUpdateAvailable = ((BridgeInformation.majorVersion < BridgeInformation.updateMajorVersion) ||
                     ((BridgeInformation.majorVersion == BridgeInformation.updateMajorVersion) && (BridgeInformation.minorVersion < BridgeInformation.updateMinorVersion))) ? 1 : 0;
             }

--- a/windows/FloppyBridge.h
+++ b/windows/FloppyBridge.h
@@ -47,7 +47,7 @@
 
 #endif 
 
-#include "..\floppybridge\CommonBridgeTemplate.h"
+#include "CommonBridgeTemplate.h"
 
 #define MAX_NUM_DRIVERS     2
 

--- a/windows/FloppyBridge.vcxproj
+++ b/windows/FloppyBridge.vcxproj
@@ -136,6 +136,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\floppybridge;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Looks like I also needed to add FloppyBridge.cpp in the library, otherwise no function existed :)
I'm not including the profile related files, as I don't need them. Hopefully they can be skipped?

The includes have been changed slightly, so the path is not hardcoded. Instead, I added an Include path in the project file for Visual Studio, and in the Makefile.

Finally, some more Linux-specific functions and pieces were changed, to allow it to compile.