### PR TITLE
Added missing includes - fixes compile under GCC14 on Linux

### DIFF
--- a/floppybridge/CommonBridgeTemplate.h
+++ b/floppybridge/CommonBridgeTemplate.h
@@ -29,6 +29,7 @@
 // Everything in protected needs implementing, but that's a lot less logic than on your own
 // All the thread sync and WinUAE i/o is done for you in this class
 
+#include <string>
 #include <thread>
 #include <functional>
 #include <queue>

--- a/floppybridge/SerialIO.h
+++ b/floppybridge/SerialIO.h
@@ -26,6 +26,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 #ifdef _WIN32
 #ifdef USING_MFC


### PR DESCRIPTION
Looks like GCC 14 is more strict about these, and if they are not included it fails to build